### PR TITLE
fix: chat completion with openai api >= 1.0.0

### DIFF
--- a/infiniteGPT/blastoff.py
+++ b/infiniteGPT/blastoff.py
@@ -18,7 +18,7 @@ def save_to_file(responses, output_file):
 # Change your OpenAI chat model accordingly
 
 def call_openai_api(chunk):
-    response = openai.ChatCompletion.create(
+    response = openai.chat.completions.create(
         model="gpt-3.5-turbo",
         messages=[
             {"role": "system", "content": "PASS IN ANY ARBITRARY SYSTEM VALUE TO GIVE THE AI AN IDENITY"},


### PR DESCRIPTION
### Error
```
You tried to access openai.ChatCompletion, but this is no longer supported in openai>=1.0.0"
```

### Fix
`client.ChatCompletion.create` --> `client.chat.completions.create`

### Docs
E.g., see: 
* https://github.com/openai/openai-python/blob/main/api.md
* https://stackoverflow.com/questions/77505030/openai-api-error-you-tried-to-access-openai-chatcompletion-but-this-is-no-lon
